### PR TITLE
Create image with node 12 on it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ parameters:
 jobs:
 
   build:
-    branches:
-      only:
-        - master
     environment:
       DOCKER_IMAGE: "circleci-deploy"
     docker:  
@@ -56,3 +53,11 @@ jobs:
           command: |            
             docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$TAG
             docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:latest
+
+workflows:
+  build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ parameters:
 jobs:
 
   build:
+    branches:
+      only:
+        - master
     environment:
       DOCKER_IMAGE: "circleci-deploy"
     docker:  
@@ -31,7 +34,7 @@ jobs:
             echo 'if [ -z "$AWS_ACCESS_KEY_ID" ]; then export AWS_ACCESS_KEY_ID="${<< pipeline.parameters.aws_prefix >>AWS_ACCESS_KEY_ID}"; fi' >> $BASH_ENV
             echo 'export AWS_SECRET_ACCESS_KEY="${<< pipeline.parameters.aws_prefix >>AWS_SECRET_ACCESS_KEY}"' >> $BASH_ENV
             echo 'if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then export AWS_SECRET_ACCESS_KEY="${<< pipeline.parameters.aws_prefix >>AWS_SECRET_KEY}"; fi' >> $BASH_ENV
-            echo 'export TAG=0.1.$CIRCLE_BUILD_NUM' >> $BASH_ENV
+            echo 'export TAG=0.2.$CIRCLE_BUILD_NUM' >> $BASH_ENV
             echo 'export DOCKER_REGISTRY=$<< pipeline.parameters.aws_prefix >>AWS_ACCOUNT_ID.dkr.ecr.$ECR_AWS_REGION.amazonaws.com' >> $BASH_ENV
             source $BASH_ENV
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.18.0-alpine3.11
+FROM node:12.17.0-alpine3.11
 
 RUN apk add --no-cache --update grep make git curl jq wget util-linux zip bash busybox busybox-extras util-linux openssl openssh socat groff less g++ libffi-dev openssl-dev libxml2-dev libxslt-dev ca-certificates && \
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docker images with tools to support CircleCI builds.
 
 Includes:
 
- - Node 10
+ - Node 12
  - AWS CLI
  - Transcrypt
  - Terraform


### PR DESCRIPTION
## Required Reviewer(s)
@alerosa 

## Description of changes
- Update node version in Dockerfile
- Update CI config to only run on master and to tag new images as `0.2.x`

## Motivation/Context
I want to use the latest active LTS version of node for the new match score API which is v12. This change will build and create a new `0.2.0` version of the circleci-deploy image which can be used in the monorepo's CI for building/testing/deploying the new match score 